### PR TITLE
fix tokenstream index out of bounds

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -23,19 +23,19 @@ impl<'a> CangjieTokenStream<'a> {
 impl<'a> ::tantivy::tokenizer::TokenStream for CangjieTokenStream<'a> {
     fn advance(&mut self) -> bool {
         if self.index < self.result.len() {
-            self.index += 1;
-
-            let current_word = self.result[self.index - 1];
-
-            self.offset_from += current_word.len();
+            let current_word = self.result[self.index];
+            let offset_to = self.offset_from + current_word.len();
 
             self.token = Token {
                 offset_from: self.offset_from,
-                offset_to: self.offset_from + current_word.len(),
+                offset_to,
                 position: self.index,
                 text: current_word.to_string(),
                 position_length: self.result.len(),
             };
+
+            self.index += 1;
+            self.offset_from = offset_to;
             true
         } else {
             false


### PR DESCRIPTION
`offset_from`, `position` start with `0`, same as tantivy default segmentation.