### PR TITLE
chore: bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ readme = "README.MD"
 keywords = ["search", "tokenizer", "Chinese", "tantivy"]
 
 [dependencies]
-tantivy = "0.21.1"
-jieba-rs = { version = "0.6.8", default-features = false }
-log = "0.4.20"
+tantivy = "0.22.0"
+jieba-rs = { version = "0.7.0", default-features = false }
+log = "0.4.22"
 
 [dev-dependencies]
-jieba-rs = { version = "0.6.8", default-features = true }
-flexi_logger = "0.27.2"
+jieba-rs = { version = "0.7.0", default-features = true }
+flexi_logger = "0.29.6"

--- a/tests/position.rs
+++ b/tests/position.rs
@@ -7,7 +7,7 @@ use tantivy::{
     doc,
     query::QueryParser,
     schema::{IndexRecordOption, SchemaBuilder, TextFieldIndexing, TextOptions},
-    Index, SnippetGenerator,
+    Index, SnippetGenerator, TantivyDocument,
 };
 
 #[test]
@@ -41,7 +41,7 @@ fn test_tokenizer_position() -> tantivy::Result<()> {
 
     let snippet = SnippetGenerator::create(&searcher, &query, title).unwrap();
     for doc in top_docs.iter() {
-        let s = snippet.snippet_from_doc(&searcher.doc(doc.1).unwrap());
+        let s = snippet.snippet_from_doc(&searcher.doc::<TantivyDocument>(doc.1).unwrap());
         dbg!(s.to_html());
     }
     Ok(())

--- a/tests/unicode_split.rs
+++ b/tests/unicode_split.rs
@@ -43,11 +43,11 @@ fn full_test_unicode_split() -> tantivy::Result<()> {
         .into_iter()
         .map(|x| {
             searcher
-                .doc(x.1)
+                .doc::<TantivyDocument>(x.1)
                 .unwrap()
                 .get_first(title)
                 .unwrap()
-                .as_text()
+                .as_str()
                 .unwrap()
                 .to_string()
         })


### PR DESCRIPTION
Update dependency compatibility for the Tantivy 0.22 line.

- Bump `tantivy` from 0.21.1 to 0.22.0.
- Bump `jieba-rs` from 0.6.8 to 0.7.0.
- Refresh `log` and `flexi_logger` to compatible versions.
- Adjust tests for Tantivy 0.22 document/value APIs by using `TantivyDocument` and `as_str()`.

BREAKING CHANGE: `cang-jie` now targets Tantivy 0.22. Downstream users still on Tantivy 0.21 need to upgrade their Tantivy integration before using this change. Code that directly constructs `CangJieTokenizer` may also need the matching `jieba-rs` 0.7 `Jieba` type.
