### PR TITLE
chore(actions): refresh GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
@@ -25,7 +25,7 @@ jobs:
       matrix:
         toolchain: [ stable, beta, nightly ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,15 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - run: rustup toolchain install stable --profile minimal
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo +stable publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Why

Bring the dormant GitHub Actions setup up to date and remove the long-lived crates.io publishing secret from the release path.

## What

- Update `actions/checkout` from `v3` to `v6`.
- Publish with crates.io Trusted Publishing via `rust-lang/crates-io-auth-action@v1`.
- Keep the release job permissions limited to `contents: read` and `id-token: write`.

## Validation

- Checked upstream action versions.
- Created the crates.io Trusted Publisher for `DCjanus/cang-jie` and `release.yml`.
- Parsed `release.yml` and ran `git diff --check`.
