### PR TITLE
chore: refresh dependencies and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,22 @@ jobs:
         with:
           toolchain: stable
       - run: cargo publish --dry-run
+
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v6
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+          use_oidc: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           toolchain: nightly
           components: clippy, rustfmt
       - uses: j178/prek-action@v2
+        with:
+          extra-args: --all-files --skip cargo-test
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [ 1.88.0, stable, beta, nightly ]
+        toolchain: [ 1.88.0, beta, nightly ]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # Stable is covered by the coverage job, which runs instrumented tests.
         toolchain: [ 1.88.0, beta, nightly ]
     steps:
       - uses: actions/checkout@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cang-jie"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["DCjanus <DCjanus@dcjanus.com>"]
 edition = "2024"
 rust-version = "1.88"
@@ -11,10 +11,10 @@ readme = "README.md"
 keywords = ["search", "tokenizer", "Chinese", "tantivy"]
 
 [dependencies]
-tantivy = "0.22.0"
-jieba-rs = { version = "0.7.0", default-features = false }
-log = "0.4.22"
+jieba-rs = { version = "0.9.0", default-features = false }
+log = "0.4.29"
+tantivy = "0.26.1"
 
 [dev-dependencies]
-jieba-rs = { version = "0.7.0", default-features = true }
-flexi_logger = "0.29.6"
+flexi_logger = "0.31.8"
+jieba-rs = { version = "0.9.0", default-features = true }

--- a/README.md
+++ b/README.md
@@ -18,26 +18,30 @@ use tantivy::{
     Index,
 };
 
-let mut schema_builder = SchemaBuilder::default();
-let text_indexing = TextFieldIndexing::default()
-    .set_tokenizer(CANG_JIE)
-    .set_index_option(IndexRecordOption::WithFreqsAndPositions);
-let text_options = TextOptions::default()
-    .set_indexing_options(text_indexing)
-    .set_stored();
-let title = schema_builder.add_text_field("title", text_options);
-let schema = schema_builder.build();
+fn main() -> tantivy::Result<()> {
+    let mut schema_builder = SchemaBuilder::default();
+    let text_indexing = TextFieldIndexing::default()
+        .set_tokenizer(CANG_JIE)
+        .set_index_option(IndexRecordOption::WithFreqsAndPositions);
+    let text_options = TextOptions::default()
+        .set_indexing_options(text_indexing)
+        .set_stored();
+    let title = schema_builder.add_text_field("title", text_options);
+    let schema = schema_builder.build();
 
-let index = Index::create_in_ram(schema);
-let tokenizer = CangJieTokenizer {
-    worker: Arc::new(Jieba::new()),
-    option: TokenizerOption::Default { hmm: false },
-};
-index.tokenizers().register(CANG_JIE, tokenizer);
+    let index = Index::create_in_ram(schema);
+    let tokenizer = CangJieTokenizer {
+        worker: Arc::new(Jieba::new()),
+        option: TokenizerOption::Default { hmm: false },
+    };
+    index.tokenizers().register(CANG_JIE, tokenizer);
 
-let mut index_writer = index.writer(50 * 1024 * 1024)?;
-index_writer.add_document(doc! { title => "南京长江大桥" })?;
-index_writer.commit()?;
+    let mut index_writer = index.writer(50 * 1024 * 1024)?;
+    index_writer.add_document(doc! { title => "南京长江大桥" })?;
+    index_writer.commit()?;
+
+    Ok(())
+}
 ```
 
 See [unicode_split.rs](./tests/unicode_split.rs) for a complete searchable example.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/cang-jie.svg)](https://crates.io/crates/cang-jie)
 [![latest document](https://img.shields.io/badge/latest-document-ff69b4.svg)](https://docs.rs/cang-jie/)
 [![dependency status](https://deps.rs/repo/github/dcjanus/cang-jie/status.svg)](https://deps.rs/repo/github/dcjanus/cang-jie)
+[![codecov](https://codecov.io/gh/DCjanus/cang-jie/branch/master/graph/badge.svg)](https://app.codecov.io/gh/DCjanus/cang-jie)
 
 Chinese tokenizer integration for [Tantivy](https://github.com/quickwit-oss/tantivy), backed by [jieba-rs](https://github.com/messense/jieba-rs).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 pub use crate::{
     options::TokenizerOption, stream::CangjieTokenStream, tokenizer::CangJieTokenizer,
 };

--- a/tests/position.rs
+++ b/tests/position.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use cang_jie::{CANG_JIE, CangJieTokenizer, TokenizerOption};
 use jieba_rs::Jieba;
 use tantivy::{
-    Index, SnippetGenerator, TantivyDocument,
+    Index, TantivyDocument,
     collector::TopDocs,
     doc,
     query::QueryParser,
     schema::{IndexRecordOption, SchemaBuilder, TextFieldIndexing, TextOptions},
+    snippet::SnippetGenerator,
 };
 
 #[test]
@@ -37,7 +38,7 @@ fn test_tokenizer_position() -> tantivy::Result<()> {
     let searcher = reader.searcher();
 
     let query = QueryParser::for_index(&index, vec![title]).parse_query("南京")?;
-    let top_docs = searcher.search(query.as_ref(), &TopDocs::with_limit(10000))?;
+    let top_docs = searcher.search(query.as_ref(), &TopDocs::with_limit(10000).order_by_score())?;
 
     let snippet = SnippetGenerator::create(&searcher, &query, title).unwrap();
     for doc in top_docs.iter() {

--- a/tests/unicode_split.rs
+++ b/tests/unicode_split.rs
@@ -37,7 +37,7 @@ fn full_test_unicode_split() -> tantivy::Result<()> {
     let searcher = reader.searcher();
 
     let query = QueryParser::for_index(&index, vec![title]).parse_query("京长")?;
-    let top_docs = searcher.search(query.as_ref(), &TopDocs::with_limit(10000))?;
+    let top_docs = searcher.search(query.as_ref(), &TopDocs::with_limit(10000).order_by_score())?;
 
     let actual = top_docs
         .into_iter()


### PR DESCRIPTION
## Why

- Refresh the dependency stack around the current Tantivy tokenizer API.
- Keep CI coverage, README examples, and release checks aligned with the updated crate.

## What

- Update `tantivy` to `0.26.1`, `jieba-rs` to `0.9.0`, `log` to `0.4.29`, and `flexi_logger` to `0.31.8`.
- Bump this crate to `0.19.0` and adapt tests for Tantivy 0.26 API changes.
- Run the README usage snippet as a doctest.
- Add Codecov coverage upload with `cargo llvm-cov`; the coverage job now covers the stable test lane.
- Skip duplicate `cargo-test` execution in the CI lint job.

## Breaking Change

- This crate now targets `tantivy 0.26`.
- Downstream users should update their Tantivy dependency and adapt related Tantivy API usage.

## Validation

- `prek run --all-files`
- `cargo test --doc`
- `rustup run 1.88.0 cargo test --workspace`
- `cargo llvm-cov --workspace --lcov --output-path lcov.info`
- `cargo publish --dry-run --allow-dirty`
- GitHub Actions: `test`, `lint`, `coverage`, and `publish-dry-run`
