### PR TITLE
chore: harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - run: rustup toolchain install stable --profile minimal
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - name: Check release tag matches crate version
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
@@ -22,6 +24,6 @@ jobs:
           fi
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
-      - run: cargo +stable publish
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: rustup toolchain install stable --profile minimal
+      - name: Check release tag matches crate version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          crate_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+
+          if [ "$tag_version" != "$crate_version" ]; then
+            echo "release tag v${tag_version} does not match Cargo.toml version ${crate_version}" >&2
+            exit 1
+          fi
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - run: cargo +stable publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Project Guidance
+
+## Release Tasks
+
+For tasks that involve releasing, publishing, tagging, changing `.github/workflows/release.yml`, or editing GitHub release notes, read [release.md](docs/release.md) before making changes.

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,6 +11,7 @@ This crate publishes to crates.io from GitHub Actions when a `vX.Y.Z` tag is pus
 ## Tag Version Rule
 
 Release tags use the `vX.Y.Z` format. The version in the tag must match `package.version` in [Cargo.toml](../Cargo.toml).
+Versions must follow [Semantic Versioning](https://semver.org/).
 
 [release.yml](../.github/workflows/release.yml) checks this before authenticating to crates.io or running `cargo publish`.
 
@@ -32,3 +33,16 @@ Keep release notes short and focused:
 - Write a compact `Highlights` section.
 - Keep `Breaking Changes` separate when compatibility changes exist.
 - Preserve GitHub's generated `What's Changed`, `New Contributors`, and `Full Changelog` sections when useful.
+
+Create the release from a local notes file and GitHub's generated sections:
+
+```console
+gh release create vX.Y.Z \
+  --verify-tag \
+  --notes-start-tag vA.B.C \
+  --title "vX.Y.Z" \
+  --notes-file /tmp/cang-jie-vX.Y.Z-notes.md \
+  --generate-notes
+```
+
+Here, `vX.Y.Z` is `tag_name`, and `--notes-start-tag vA.B.C` is `previous_tag_name`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,37 @@
+# Release Process
+
+This crate publishes to crates.io from GitHub Actions when a `vX.Y.Z` tag is pushed.
+
+## Before Tagging
+
+- Work from the latest `master`.
+- Confirm `Cargo.toml` has the version being released.
+- Run `prek run --all-files`.
+- Run `cargo publish --dry-run`.
+- Confirm the latest `master` CI run is green.
+
+## Tag Version Rule
+
+Release tags use the `vX.Y.Z` format. The version in the tag must match `package.version` in [Cargo.toml](../Cargo.toml).
+
+[release.yml](../.github/workflows/release.yml) checks this before authenticating to crates.io or running `cargo publish`.
+
+## Publishing
+
+Push the tag to trigger the release workflow:
+
+```console
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Wait for the release workflow to finish, then confirm the version is visible on crates.io before creating the GitHub Release.
+
+## GitHub Release Notes
+
+Keep release notes short and focused:
+
+- Write a compact `Highlights` section.
+- Keep `Breaking Changes` separate when compatibility changes exist.
+- Preserve GitHub's generated `What's Changed`, `New Contributors`, and `Full Changelog` sections when useful.
+- Set the changelog comparison range to the crate version range, not necessarily the previous GitHub Release. For example, `v0.18.0...v0.19.0`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,8 +6,6 @@ This crate publishes to crates.io from GitHub Actions when a `vX.Y.Z` tag is pus
 
 - Work from the latest `master`.
 - Confirm `Cargo.toml` has the version being released.
-- Run `prek run --all-files`.
-- Run `cargo publish --dry-run`.
 - Confirm the latest `master` CI run is green.
 
 ## Tag Version Rule
@@ -34,4 +32,3 @@ Keep release notes short and focused:
 - Write a compact `Highlights` section.
 - Keep `Breaking Changes` separate when compatibility changes exist.
 - Preserve GitHub's generated `What's Changed`, `New Contributors`, and `Full Changelog` sections when useful.
-- Set the changelog comparison range to the crate version range, not necessarily the previous GitHub Release. For example, `v0.18.0...v0.19.0`.


### PR DESCRIPTION
## Why

- Prevent release tags from publishing the wrong crate version.
- Keep the release workflow and release-note style easy to follow for future maintenance.

## What

- Add a release workflow check that requires `vX.Y.Z` tags to match `Cargo.toml` `package.version`.
- Use the stable Rust toolchain action before running release checks and `cargo publish`.
- Document the release process, GitHub release-note command, and release-related agent guidance.

## Validation

- `GITHUB_REF_NAME=v0.19.0` version check passes locally.
- `GITHUB_REF_NAME=v9.9.9` version check fails locally as expected.
- `prek run --all-files`
