### PR TITLE
chore: enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies


### PR DESCRIPTION
## Why

- Keep Rust dependencies and GitHub Actions versions visible when updates are available.
- Let dependency update review happen through normal pull requests instead of manual checks.

## What

- Add Dependabot configuration for Cargo dependencies in the repository root.
- Add Dependabot configuration for GitHub Actions workflows.
- Limit each ecosystem to 5 open dependency PRs and apply the `dependencies` label.
