### PR TITLE
ci: add release semver gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.3.1
         with:
           version: "0.11.27"
           python-version: "3.13"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,17 @@ jobs:
           toolchain: stable
       - run: cargo publish --dry-run
 
+  release-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8
+        with:
+          version: "0.11.27"
+          python-version: "3.13"
+          enable-cache: true
+      - run: scripts/check_release_semver.py --self-test
+
   coverage:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+      - uses: astral-sh/setup-uv@v8
+        with:
+          version: "0.11.27"
+          python-version: "3.13"
+          enable-cache: true
       - uses: taiki-e/install-action@cargo-semver-checks
-      - name: Check release tag matches crate version
-        run: |
-          tag_version="${GITHUB_REF_NAME#v}"
-          crate_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
-
-          if [ "$tag_version" != "$crate_version" ]; then
-            echo "release tag v${tag_version} does not match Cargo.toml version ${crate_version}" >&2
-            exit 1
-          fi
-      - name: Check release SemVer compatibility
+      - name: Check release SemVer gate
         run: scripts/check_release_semver.py
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.3.1
         with:
           version: "0.11.27"
           python-version: "3.13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,12 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+      - uses: taiki-e/install-action@cargo-semver-checks
       - name: Check release tag matches crate version
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
@@ -22,6 +25,8 @@ jobs:
             echo "release tag v${tag_version} does not match Cargo.toml version ${crate_version}" >&2
             exit 1
           fi
+      - name: Check release SemVer compatibility
+        run: scripts/check_release_semver.py
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - run: cargo publish

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,21 +13,27 @@ This crate publishes to crates.io from GitHub Actions when a `vX.Y.Z` tag is pus
 Release tags use the `vX.Y.Z` format. The version in the tag must match `package.version` in [Cargo.toml](../Cargo.toml).
 Versions must follow [Semantic Versioning](https://semver.org/).
 
-[release.yml](../.github/workflows/release.yml) checks this before authenticating to crates.io or running `cargo publish`.
+[release.yml](../.github/workflows/release.yml) installs `uv` and runs [check_release_semver.py](../scripts/check_release_semver.py) before authenticating to crates.io or running `cargo publish`.
 
 ## SemVer Gate
 
-The release workflow runs [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) before authenticating to crates.io.
+The release workflow runs the release gate script before authenticating to crates.io. The script checks:
 
-For stable tags, [check_release_semver.py](../scripts/check_release_semver.py) selects the latest compatible baseline tag:
+- The release tag matches `package.version` in [Cargo.toml](../Cargo.toml).
+- Stable release tags move forward according to Semantic Versioning.
+- Compatible stable release lines do not introduce breaking public API changes.
 
-- `0.y.z` patch releases compare against the latest `v0.y.*` tag.
+For stable tags, the script selects the latest compatible baseline tag:
+
+- `0.y.z` patch releases compare against the latest lower `v0.y.*` tag.
 - `1.y.z` and later compare against the latest lower tag with the same major version.
 - New effective-major release lines, such as `v0.20.0` after `v0.19.0`, allow breaking changes and skip strict blocking.
 
-Pre-release tags such as `v0.20.0-alpha.1` currently skip strict SemVer enforcement. Define a release-line policy before relying on pre-release tags for compatibility guarantees.
+Maintenance releases are allowed after a newer release line only when the tag has a lower compatible baseline in the same line, such as `v0.19.1` after `v0.19.0`. Starting an older release line after a newer stable tag is blocked.
 
-The gate also compiles a small downstream crate that uses the documented direct `CangJieTokenizer` construction pattern with the baseline `jieba-rs` requirement. This catches public dependency breaks that rustdoc-level SemVer checks may miss.
+Pre-release tags such as `v0.20.0-alpha.1` currently validate the tag/Cargo version match but skip strict SemVer enforcement. Define a release-line policy before relying on pre-release tags for compatibility guarantees.
+
+For compatible stable release lines, the gate runs [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks). It also compiles a small downstream crate that uses the documented direct `CangJieTokenizer` construction pattern with the baseline `jieba-rs` requirement. This catches public dependency breaks that rustdoc-level SemVer checks may miss.
 
 ## Publishing
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -25,7 +25,7 @@ The release workflow runs the release gate script before authenticating to crate
 
 For stable tags, the script selects the latest compatible baseline tag:
 
-- `0.y.z` patch releases compare against the latest lower `v0.y.*` tag.
+- `0.y.z` patch releases, where `y > 0`, compare against the latest lower `v0.y.*` tag.
 - `1.y.z` and later compare against the latest lower tag with the same major version.
 - New effective-major release lines, such as `v0.20.0` after `v0.19.0`, allow breaking changes and skip strict blocking.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -33,7 +33,7 @@ Maintenance releases are allowed after a newer release line only when the tag ha
 
 Pre-release tags such as `v0.20.0-alpha.1` currently validate the tag/Cargo version match but skip strict SemVer enforcement. Define a release-line policy before relying on pre-release tags for compatibility guarantees.
 
-For compatible stable release lines, the gate runs [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks). It also compiles a small downstream crate that uses the documented direct `CangJieTokenizer` construction pattern with the baseline `jieba-rs` requirement. This catches public dependency breaks that rustdoc-level SemVer checks may miss.
+For compatible stable release lines, the gate runs [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks). It also compiles a small downstream crate that uses the documented direct `CangJieTokenizer` construction pattern with the baseline `jieba-rs` version and the default features needed by `Jieba::new()`. This catches public dependency breaks that rustdoc-level SemVer checks may miss.
 
 ## Publishing
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,6 +15,20 @@ Versions must follow [Semantic Versioning](https://semver.org/).
 
 [release.yml](../.github/workflows/release.yml) checks this before authenticating to crates.io or running `cargo publish`.
 
+## SemVer Gate
+
+The release workflow runs [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) before authenticating to crates.io.
+
+For stable tags, [check_release_semver.py](../scripts/check_release_semver.py) selects the latest compatible baseline tag:
+
+- `0.y.z` patch releases compare against the latest `v0.y.*` tag.
+- `1.y.z` and later compare against the latest lower tag with the same major version.
+- New effective-major release lines, such as `v0.20.0` after `v0.19.0`, allow breaking changes and skip strict blocking.
+
+Pre-release tags such as `v0.20.0-alpha.1` currently skip strict SemVer enforcement. Define a release-line policy before relying on pre-release tags for compatibility guarantees.
+
+The gate also compiles a small downstream crate that uses the documented direct `CangJieTokenizer` construction pattern with the baseline `jieba-rs` requirement. This catches public dependency breaks that rustdoc-level SemVer checks may miss.
+
 ## Publishing
 
 Push the tag to trigger the release workflow:

--- a/scripts/check_release_semver.py
+++ b/scripts/check_release_semver.py
@@ -197,6 +197,7 @@ def run_public_dependency_smoke(repo: Path, baseline_tag: str) -> None:
     )
     with tempfile.TemporaryDirectory(prefix="cang-jie-public-dep-") as tmp:
         crate = Path(tmp)
+        repo_path = toml_literal(str(repo))
         (crate / "src").mkdir()
         (crate / "Cargo.toml").write_text(
             textwrap.dedent(
@@ -207,7 +208,7 @@ def run_public_dependency_smoke(repo: Path, baseline_tag: str) -> None:
                 edition = "2024"
 
                 [dependencies]
-                cang-jie = {{ path = {str(repo)!r} }}
+                cang-jie = {{ path = {repo_path} }}
                 jieba-rs = {jieba_requirement}
                 """
             ),
@@ -299,6 +300,7 @@ def self_test() -> None:
         render_dependency_requirement({"version": "0.9.0", "default-features": False})
         == '{ version = "0.9.0", default-features = false }'
     )
+    assert toml_literal(r"C:\tmp\cang-jie") == r'"C:\\tmp\\cang-jie"'
     assert not is_stable(parse_tag_version("v0.20.0-alpha.1"))
     console.print("self-test passed")
 

--- a/scripts/check_release_semver.py
+++ b/scripts/check_release_semver.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Block incompatible stable releases before publishing to crates.io."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+STABLE_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+    stable: bool = True
+
+    @classmethod
+    def parse(cls, value: str) -> "Version":
+        stable_match = STABLE_VERSION_RE.match(value)
+        if stable_match:
+            return cls(*(int(part) for part in stable_match.groups()), stable=True)
+
+        match = VERSION_RE.match(value)
+        if not match:
+            raise ValueError(f"unsupported version format: {value}")
+        return cls(*(int(part) for part in match.groups()), stable=False)
+
+    def is_compatible_line_with(self, other: "Version") -> bool:
+        if not self.stable or not other.stable:
+            return False
+        if self.major == 0:
+            return self.minor != 0 and other.major == 0 and other.minor == self.minor
+        return other.major == self.major
+
+
+def run(args: list[str], *, cwd: Path, capture: bool = False) -> str:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+    )
+    return result.stdout if capture else ""
+
+
+def cargo_package_version(repo: Path) -> str:
+    metadata = run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+        cwd=repo,
+        capture=True,
+    )
+    import json
+
+    return json.loads(metadata)["packages"][0]["version"]
+
+
+def stable_tags(repo: Path) -> list[tuple[Version, str]]:
+    tags = run(["git", "tag", "--list", "v*"], cwd=repo, capture=True).splitlines()
+    versions = []
+    for tag in tags:
+        try:
+            version = Version.parse(tag)
+        except ValueError:
+            continue
+        if version.stable:
+            versions.append((version, tag))
+    return sorted(versions)
+
+
+def compatible_baseline_tag(
+    current: Version, tags: list[tuple[Version, str]]
+) -> str | None:
+    candidates = [
+        (version, tag)
+        for version, tag in tags
+        if version < current and current.is_compatible_line_with(version)
+    ]
+    return candidates[-1][1] if candidates else None
+
+
+def baseline_jieba_requirement(repo: Path, baseline_tag: str) -> str | None:
+    cargo_toml = run(
+        ["git", "show", f"{baseline_tag}:Cargo.toml"], cwd=repo, capture=True
+    )
+    manifest = tomllib.loads(cargo_toml)
+    dependency = manifest.get("dependencies", {}).get("jieba-rs")
+    if isinstance(dependency, str):
+        return dependency
+    if isinstance(dependency, dict):
+        version = dependency.get("version")
+        return str(version) if version else None
+    return None
+
+
+def run_public_dependency_smoke(repo: Path, baseline_tag: str) -> None:
+    jieba_requirement = baseline_jieba_requirement(repo, baseline_tag)
+    if not jieba_requirement:
+        print(
+            "No baseline jieba-rs dependency found; skipping public dependency smoke test."
+        )
+        return
+
+    print(
+        "Checking documented CangJieTokenizer construction against "
+        f"baseline jieba-rs requirement {jieba_requirement!r}."
+    )
+    with tempfile.TemporaryDirectory(prefix="cang-jie-public-dep-") as tmp:
+        crate = Path(tmp)
+        (crate / "src").mkdir()
+        (crate / "Cargo.toml").write_text(
+            textwrap.dedent(
+                f"""\
+                [package]
+                name = "cang-jie-public-dependency-smoke"
+                version = "0.0.0"
+                edition = "2024"
+
+                [dependencies]
+                cang-jie = {{ path = {str(repo)!r} }}
+                jieba-rs = {jieba_requirement!r}
+                """
+            ),
+            encoding="utf-8",
+        )
+        (crate / "src/lib.rs").write_text(
+            textwrap.dedent(
+                """\
+                use std::sync::Arc;
+
+                use cang_jie::{CangJieTokenizer, TokenizerOption};
+                use jieba_rs::Jieba;
+
+                pub fn tokenizer() -> CangJieTokenizer {
+                    CangJieTokenizer {
+                        worker: Arc::new(Jieba::new()),
+                        option: TokenizerOption::Default { hmm: false },
+                    }
+                }
+                """
+            ),
+            encoding="utf-8",
+        )
+        run(["cargo", "check", "--manifest-path", str(crate / "Cargo.toml")], cwd=repo)
+
+
+def check_release(repo: Path, tag_name: str) -> None:
+    tag_version = tag_name.removeprefix("v")
+    crate_version = cargo_package_version(repo)
+    if tag_version != crate_version:
+        raise SystemExit(
+            f"release tag {tag_name} does not match Cargo.toml version {crate_version}"
+        )
+
+    current = Version.parse(tag_name)
+    if not current.stable:
+        print(f"{tag_name} is a pre-release tag; skipping strict SemVer gate.")
+        return
+
+    baseline_tag = compatible_baseline_tag(current, stable_tags(repo))
+    if baseline_tag is None:
+        print(
+            f"{tag_name} starts a new effective-major release line; "
+            "breaking changes are allowed."
+        )
+        return
+
+    print(f"Checking SemVer compatibility against baseline {baseline_tag}.")
+    run(
+        ["cargo", "semver-checks", "check-release", "--baseline-rev", baseline_tag],
+        cwd=repo,
+    )
+    run_public_dependency_smoke(repo, baseline_tag)
+
+
+def self_test() -> None:
+    tags = [
+        (Version.parse("v0.19.0"), "v0.19.0"),
+        (Version.parse("v0.20.0"), "v0.20.0"),
+        (Version.parse("v1.2.3"), "v1.2.3"),
+        (Version.parse("v1.3.0"), "v1.3.0"),
+    ]
+    assert compatible_baseline_tag(Version.parse("v0.20.1"), tags) == "v0.20.0"
+    assert compatible_baseline_tag(Version.parse("v0.21.0"), tags) is None
+    assert compatible_baseline_tag(Version.parse("v1.3.1"), tags) == "v1.3.0"
+    assert compatible_baseline_tag(Version.parse("v1.4.0"), tags) == "v1.3.0"
+    assert not Version.parse("v0.20.0-alpha.1").stable
+    print("self-test passed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--tag", default=os.environ.get("GITHUB_REF_NAME"))
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        return
+    if not args.tag:
+        raise SystemExit("--tag or GITHUB_REF_NAME is required")
+    if shutil.which("cargo-semver-checks") is None:
+        raise SystemExit("cargo-semver-checks is required")
+
+    check_release(args.repo.resolve(), args.tag)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_release_semver.py
+++ b/scripts/check_release_semver.py
@@ -149,18 +149,38 @@ def check_stable_version_progression(
     )
 
 
+def toml_literal(value: object) -> str:
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return f"[{', '.join(json.dumps(item) for item in value)}]"
+    fail(f"unsupported Cargo.toml dependency value: {value!r}")
+
+
+def render_dependency_requirement(dependency: object) -> str | None:
+    if isinstance(dependency, str):
+        return toml_literal(dependency)
+    if not isinstance(dependency, dict):
+        return None
+
+    supported_keys = ["version", "default-features", "features"]
+    items = [
+        f"{key} = {toml_literal(dependency[key])}"
+        for key in supported_keys
+        if key in dependency
+    ]
+    return f"{{ {', '.join(items)} }}" if items else None
+
+
 def baseline_jieba_requirement(repo: Path, baseline_tag: str) -> str | None:
     cargo_toml = run(
         ["git", "show", f"{baseline_tag}:Cargo.toml"], cwd=repo, capture=True
     )
     manifest = tomllib.loads(cargo_toml)
     dependency = manifest.get("dependencies", {}).get("jieba-rs")
-    if isinstance(dependency, str):
-        return dependency
-    if isinstance(dependency, dict):
-        version = dependency.get("version")
-        return str(version) if version else None
-    return None
+    return render_dependency_requirement(dependency)
 
 
 def run_public_dependency_smoke(repo: Path, baseline_tag: str) -> None:
@@ -188,7 +208,7 @@ def run_public_dependency_smoke(repo: Path, baseline_tag: str) -> None:
 
                 [dependencies]
                 cang-jie = {{ path = {str(repo)!r} }}
-                jieba-rs = {jieba_requirement!r}
+                jieba-rs = {jieba_requirement}
                 """
             ),
             encoding="utf-8",
@@ -275,6 +295,10 @@ def self_test() -> None:
             (parse_tag_version("v0.20.0"), "v0.20.0"),
         ],
     ) == (parse_tag_version("v0.19.3"), "v0.19.3")
+    assert (
+        render_dependency_requirement({"version": "0.9.0", "default-features": False})
+        == '{ version = "0.9.0", default-features = false }'
+    )
     assert not is_stable(parse_tag_version("v0.20.0-alpha.1"))
     console.print("self-test passed")
 

--- a/scripts/check_release_semver.py
+++ b/scripts/check_release_semver.py
@@ -105,20 +105,34 @@ def compatible_baseline(
     return candidates[-1] if candidates else None
 
 
+def latest_compatible_existing_tag(
+    current: Version, tags: list[tuple[Version, str]]
+) -> tuple[Version, str] | None:
+    candidates = [
+        (version, tag)
+        for version, tag in tags
+        if version != current and is_compatible_line(current, version)
+    ]
+    return candidates[-1] if candidates else None
+
+
 def check_stable_version_progression(
     tag_name: str, current: Version, tags: list[tuple[Version, str]]
 ) -> None:
-    compatible = compatible_baseline(current, tags)
-    if compatible is not None:
-        _, previous_tag = compatible
+    latest_compatible = latest_compatible_existing_tag(current, tags)
+    if latest_compatible is not None:
+        latest_version, previous_tag = latest_compatible
+        if current <= latest_version:
+            fail(
+                f"{tag_name} is not greater than latest compatible release tag "
+                f"{previous_tag}."
+            )
         console.print(
             f"Checking version progression against previous compatible tag {previous_tag}."
         )
         return
 
-    existing = [
-        (version, tag) for version, tag in tags if version.compare(current) != 0
-    ]
+    existing = [(version, tag) for version, tag in tags if version != current]
     if not existing:
         console.print(f"{tag_name} is the first stable release tag.")
         return
@@ -253,6 +267,14 @@ def self_test() -> None:
         parse_tag_version("v1.3.0"),
         "v1.3.0",
     )
+    assert latest_compatible_existing_tag(
+        parse_tag_version("v0.19.2"),
+        [
+            (parse_tag_version("v0.19.0"), "v0.19.0"),
+            (parse_tag_version("v0.19.3"), "v0.19.3"),
+            (parse_tag_version("v0.20.0"), "v0.20.0"),
+        ],
+    ) == (parse_tag_version("v0.19.3"), "v0.19.3")
     assert not is_stable(parse_tag_version("v0.20.0-alpha.1"))
     console.print("self-test passed")
 

--- a/scripts/check_release_semver.py
+++ b/scripts/check_release_semver.py
@@ -1,48 +1,38 @@
-#!/usr/bin/env python3
-"""Block incompatible stable releases before publishing to crates.io."""
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "rich>=15.0.0",
+#     "semver>=3.0.4",
+#     "typer>=0.26.8",
+# ]
+# ///
+"""Block invalid stable releases before publishing to crates.io."""
 
 from __future__ import annotations
 
-import argparse
+import json
 import os
-import re
 import shutil
 import subprocess
 import tempfile
 import textwrap
 import tomllib
-from dataclasses import dataclass
 from pathlib import Path
+from typing import Annotated
+
+import semver
+import typer
+from rich.console import Console
 
 
-STABLE_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
-VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+Version = semver.Version
+console = Console()
 
 
-@dataclass(frozen=True, order=True)
-class Version:
-    major: int
-    minor: int
-    patch: int
-    stable: bool = True
-
-    @classmethod
-    def parse(cls, value: str) -> "Version":
-        stable_match = STABLE_VERSION_RE.match(value)
-        if stable_match:
-            return cls(*(int(part) for part in stable_match.groups()), stable=True)
-
-        match = VERSION_RE.match(value)
-        if not match:
-            raise ValueError(f"unsupported version format: {value}")
-        return cls(*(int(part) for part in match.groups()), stable=False)
-
-    def is_compatible_line_with(self, other: "Version") -> bool:
-        if not self.stable or not other.stable:
-            return False
-        if self.major == 0:
-            return self.minor != 0 and other.major == 0 and other.minor == self.minor
-        return other.major == self.major
+def fail(message: str) -> None:
+    console.print(message, style="red", stderr=True)
+    raise typer.Exit(1)
 
 
 def run(args: list[str], *, cwd: Path, capture: bool = False) -> str:
@@ -62,33 +52,87 @@ def cargo_package_version(repo: Path) -> str:
         cwd=repo,
         capture=True,
     )
-    import json
-
     return json.loads(metadata)["packages"][0]["version"]
+
+
+def parse_tag_version(tag_name: str) -> Version:
+    version = tag_name.removeprefix("v")
+    try:
+        return Version.parse(version)
+    except ValueError as exc:
+        fail(f"release tag {tag_name!r} is not a valid Semantic Version: {exc}")
+
+
+def parse_existing_tag_version(tag_name: str) -> Version | None:
+    try:
+        return Version.parse(tag_name.removeprefix("v"))
+    except ValueError:
+        return None
+
+
+def is_stable(version: Version) -> bool:
+    return version.prerelease is None
+
+
+def is_compatible_line(current: Version, other: Version) -> bool:
+    if not is_stable(current) or not is_stable(other):
+        return False
+    if current.major == 0:
+        return current.minor != 0 and other.major == 0 and other.minor == current.minor
+    return other.major == current.major
 
 
 def stable_tags(repo: Path) -> list[tuple[Version, str]]:
     tags = run(["git", "tag", "--list", "v*"], cwd=repo, capture=True).splitlines()
     versions = []
     for tag in tags:
-        try:
-            version = Version.parse(tag)
-        except ValueError:
+        version = parse_existing_tag_version(tag)
+        if version is None:
             continue
-        if version.stable:
+        if is_stable(version):
             versions.append((version, tag))
     return sorted(versions)
 
 
-def compatible_baseline_tag(
+def compatible_baseline(
     current: Version, tags: list[tuple[Version, str]]
-) -> str | None:
+) -> tuple[Version, str] | None:
     candidates = [
         (version, tag)
         for version, tag in tags
-        if version < current and current.is_compatible_line_with(version)
+        if version < current and is_compatible_line(current, version)
     ]
-    return candidates[-1][1] if candidates else None
+    return candidates[-1] if candidates else None
+
+
+def check_stable_version_progression(
+    tag_name: str, current: Version, tags: list[tuple[Version, str]]
+) -> None:
+    compatible = compatible_baseline(current, tags)
+    if compatible is not None:
+        _, previous_tag = compatible
+        console.print(
+            f"Checking version progression against previous compatible tag {previous_tag}."
+        )
+        return
+
+    existing = [
+        (version, tag) for version, tag in tags if version.compare(current) != 0
+    ]
+    if not existing:
+        console.print(f"{tag_name} is the first stable release tag.")
+        return
+
+    latest_version, latest_tag = existing[-1]
+    if current <= latest_version:
+        fail(
+            f"{tag_name} is not greater than latest stable release tag {latest_tag}. "
+            "Maintenance releases need an earlier compatible baseline tag in the same release line."
+        )
+
+    console.print(
+        f"Checking version progression against latest stable tag {latest_tag}."
+    )
 
 
 def baseline_jieba_requirement(repo: Path, baseline_tag: str) -> str | None:
@@ -108,12 +152,12 @@ def baseline_jieba_requirement(repo: Path, baseline_tag: str) -> str | None:
 def run_public_dependency_smoke(repo: Path, baseline_tag: str) -> None:
     jieba_requirement = baseline_jieba_requirement(repo, baseline_tag)
     if not jieba_requirement:
-        print(
+        console.print(
             "No baseline jieba-rs dependency found; skipping public dependency smoke test."
         )
         return
 
-    print(
+    console.print(
         "Checking documented CangJieTokenizer construction against "
         f"baseline jieba-rs requirement {jieba_requirement!r}."
     )
@@ -160,24 +204,28 @@ def check_release(repo: Path, tag_name: str) -> None:
     tag_version = tag_name.removeprefix("v")
     crate_version = cargo_package_version(repo)
     if tag_version != crate_version:
-        raise SystemExit(
+        fail(
             f"release tag {tag_name} does not match Cargo.toml version {crate_version}"
         )
 
-    current = Version.parse(tag_name)
-    if not current.stable:
-        print(f"{tag_name} is a pre-release tag; skipping strict SemVer gate.")
+    current = parse_tag_version(tag_name)
+    if not is_stable(current):
+        console.print(f"{tag_name} is a pre-release tag; skipping strict SemVer gate.")
         return
 
-    baseline_tag = compatible_baseline_tag(current, stable_tags(repo))
-    if baseline_tag is None:
-        print(
+    tags = stable_tags(repo)
+    check_stable_version_progression(tag_name, current, tags)
+
+    baseline = compatible_baseline(current, tags)
+    if baseline is None:
+        console.print(
             f"{tag_name} starts a new effective-major release line; "
             "breaking changes are allowed."
         )
         return
 
-    print(f"Checking SemVer compatibility against baseline {baseline_tag}.")
+    _, baseline_tag = baseline
+    console.print(f"Checking SemVer compatibility against baseline {baseline_tag}.")
     run(
         ["cargo", "semver-checks", "check-release", "--baseline-rev", baseline_tag],
         cwd=repo,
@@ -187,36 +235,63 @@ def check_release(repo: Path, tag_name: str) -> None:
 
 def self_test() -> None:
     tags = [
-        (Version.parse("v0.19.0"), "v0.19.0"),
-        (Version.parse("v0.20.0"), "v0.20.0"),
-        (Version.parse("v1.2.3"), "v1.2.3"),
-        (Version.parse("v1.3.0"), "v1.3.0"),
+        (parse_tag_version("v0.19.0"), "v0.19.0"),
+        (parse_tag_version("v0.20.0"), "v0.20.0"),
+        (parse_tag_version("v1.2.3"), "v1.2.3"),
+        (parse_tag_version("v1.3.0"), "v1.3.0"),
     ]
-    assert compatible_baseline_tag(Version.parse("v0.20.1"), tags) == "v0.20.0"
-    assert compatible_baseline_tag(Version.parse("v0.21.0"), tags) is None
-    assert compatible_baseline_tag(Version.parse("v1.3.1"), tags) == "v1.3.0"
-    assert compatible_baseline_tag(Version.parse("v1.4.0"), tags) == "v1.3.0"
-    assert not Version.parse("v0.20.0-alpha.1").stable
-    print("self-test passed")
+    assert compatible_baseline(parse_tag_version("v0.20.1"), tags) == (
+        parse_tag_version("v0.20.0"),
+        "v0.20.0",
+    )
+    assert compatible_baseline(parse_tag_version("v0.21.0"), tags) is None
+    assert compatible_baseline(parse_tag_version("v1.3.1"), tags) == (
+        parse_tag_version("v1.3.0"),
+        "v1.3.0",
+    )
+    assert compatible_baseline(parse_tag_version("v1.4.0"), tags) == (
+        parse_tag_version("v1.3.0"),
+        "v1.3.0",
+    )
+    assert not is_stable(parse_tag_version("v0.20.0-alpha.1"))
+    console.print("self-test passed")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--repo", type=Path, default=Path.cwd())
-    parser.add_argument("--tag", default=os.environ.get("GITHUB_REF_NAME"))
-    parser.add_argument("--self-test", action="store_true")
-    args = parser.parse_args()
-
-    if args.self_test:
+def main(
+    repo: Annotated[
+        Path,
+        typer.Option(
+            "--repo",
+            help="Repository root to inspect.",
+            resolve_path=True,
+            file_okay=False,
+            dir_okay=True,
+        ),
+    ] = Path.cwd(),
+    tag: Annotated[
+        str | None,
+        typer.Option(
+            "--tag",
+            help="Release tag to validate. Defaults to GITHUB_REF_NAME.",
+        ),
+    ] = None,
+    self_test_flag: Annotated[
+        bool,
+        typer.Option("--self-test", help="Run lightweight internal assertions."),
+    ] = False,
+) -> None:
+    if self_test_flag:
         self_test()
         return
-    if not args.tag:
-        raise SystemExit("--tag or GITHUB_REF_NAME is required")
-    if shutil.which("cargo-semver-checks") is None:
-        raise SystemExit("cargo-semver-checks is required")
 
-    check_release(args.repo.resolve(), args.tag)
+    tag_name = tag or os.environ.get("GITHUB_REF_NAME")
+    if not tag_name:
+        fail("--tag or GITHUB_REF_NAME is required")
+    if shutil.which("cargo-semver-checks") is None:
+        fail("cargo-semver-checks is required")
+
+    check_release(repo.resolve(), tag_name)
 
 
 if __name__ == "__main__":
-    main()
+    typer.run(main)

--- a/scripts/check_release_semver.py
+++ b/scripts/check_release_semver.py
@@ -160,13 +160,13 @@ def toml_literal(value: object) -> str:
     fail(f"unsupported Cargo.toml dependency value: {value!r}")
 
 
-def render_dependency_requirement(dependency: object) -> str | None:
+def render_public_constructor_jieba_requirement(dependency: object) -> str | None:
     if isinstance(dependency, str):
         return toml_literal(dependency)
     if not isinstance(dependency, dict):
         return None
 
-    supported_keys = ["version", "default-features", "features"]
+    supported_keys = ["version", "features"]
     items = [
         f"{key} = {toml_literal(dependency[key])}"
         for key in supported_keys
@@ -181,7 +181,7 @@ def baseline_jieba_requirement(repo: Path, baseline_tag: str) -> str | None:
     )
     manifest = tomllib.loads(cargo_toml)
     dependency = manifest.get("dependencies", {}).get("jieba-rs")
-    return render_dependency_requirement(dependency)
+    return render_public_constructor_jieba_requirement(dependency)
 
 
 def run_public_dependency_smoke(repo: Path, baseline_tag: str) -> None:
@@ -298,8 +298,10 @@ def self_test() -> None:
         ],
     ) == (parse_tag_version("v0.19.3"), "v0.19.3")
     assert (
-        render_dependency_requirement({"version": "0.9.0", "default-features": False})
-        == '{ version = "0.9.0", default-features = false }'
+        render_public_constructor_jieba_requirement(
+            {"version": "0.9.0", "default-features": False}
+        )
+        == '{ version = "0.9.0" }'
     )
     assert toml_literal(r"C:\tmp\cang-jie") == r'"C:\\tmp\\cang-jie"'
     assert error_console.stderr

--- a/scripts/check_release_semver.py
+++ b/scripts/check_release_semver.py
@@ -28,10 +28,11 @@ from rich.console import Console
 
 Version = semver.Version
 console = Console()
+error_console = Console(stderr=True)
 
 
 def fail(message: str) -> None:
-    console.print(message, style="red", stderr=True)
+    error_console.print(message, style="red")
     raise typer.Exit(1)
 
 
@@ -301,6 +302,7 @@ def self_test() -> None:
         == '{ version = "0.9.0", default-features = false }'
     )
     assert toml_literal(r"C:\tmp\cang-jie") == r'"C:\\tmp\\cang-jie"'
+    assert error_console.stderr
     assert not is_stable(parse_tag_version("v0.20.0-alpha.1"))
     console.print("self-test passed")
 


### PR DESCRIPTION
## Why

- Release tags currently only publish after a tag/Cargo version check.
- A compatible-looking stable release can still contain detectable breaking API changes, and crates.io versions cannot be replaced after publishing.

## What

- Add a `uv` script release gate that validates the pushed tag against `Cargo.toml`, parses versions with a SemVer library, and checks stable release version progression.
- Run `cargo-semver-checks` against the latest compatible baseline tag before crates.io authentication and `cargo publish`.
- Add a cang-jie-specific downstream compile smoke test for the documented direct `CangJieTokenizer` construction pattern with the baseline `jieba-rs` requirement.
- Install `uv` in the release workflow and document the stable, maintenance, and pre-release release-line rules.

## Notes

- Stable maintenance releases are allowed after a newer release line only when they have a lower compatible baseline in the same line.
- New effective-major release lines and pre-release tags skip strict breaking-change blocking.

Closes #47
